### PR TITLE
Refactor change in reset feature

### DIFF
--- a/Library/app/build.gradle
+++ b/Library/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile project(':futbol')
     //region Material Design
     compile 'com.android.support:support-v13:23.+'
+    compile 'com.android.support:recyclerview-v7:23.+'
     //endregion
     //region Robolectric
     testCompile 'junit:junit:4.12'

--- a/Library/app/src/main/assets/json/GetDeviceOperation_1.json
+++ b/Library/app/src/main/assets/json/GetDeviceOperation_1.json
@@ -1,7 +1,7 @@
 {
   "createdAt": "2015-08-05T11:14:45.374Z",
   "id": "%s",
-  "name": "S3",
+  "name": "%s",
   "resolution": "720x1280",
   "updatedAt": "2015-08-05T11:14:45.374Z"
 }

--- a/Library/app/src/main/assets/json/GetDevicesOperation_1.json
+++ b/Library/app/src/main/assets/json/GetDevicesOperation_1.json
@@ -1,0 +1,16 @@
+[
+  {
+    "createdAt": "2015-08-05T11:14:45.374Z",
+    "id": "1",
+    "name": "Samsung S3",
+    "resolution": "720x1280",
+    "updatedAt": "2015-08-05T11:14:45.374Z"
+  },
+  {
+    "createdAt": "2015-08-05T11:14:45.374Z",
+    "id": "2",
+    "name": "Motorola Moto G",
+    "resolution": "720x1280",
+    "updatedAt": "2015-08-05T11:14:45.374Z"
+  }
+]

--- a/Library/app/src/main/java/com/globallogic/futbol/example/activities/DashboardActivity.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/activities/DashboardActivity.java
@@ -12,6 +12,7 @@ import com.globallogic.futbol.example.fragments.CreateDeviceFragment;
 import com.globallogic.futbol.example.fragments.DeleteDeviceFragment;
 import com.globallogic.futbol.example.fragments.DeletePageFragment;
 import com.globallogic.futbol.example.fragments.GetDeviceFragment;
+import com.globallogic.futbol.example.fragments.GetDevicesFragment;
 import com.globallogic.futbol.example.fragments.GetExampleTimeOutFragment;
 import com.globallogic.futbol.example.fragments.GetPageFragment;
 import com.globallogic.futbol.example.fragments.PostPageFragment;
@@ -44,6 +45,13 @@ public class DashboardActivity extends Activity implements GetPageFragment.ICall
         startActivity(GenericExampleActivity.generateIntent(this, tag));
     }
 
+    @Override
+    public void onExampleGetListSuccess() {
+        if (isTwoPane)
+            addFragment(GetDevicesFragment.newInstance(), GetDevicesFragment.TAG);
+        else
+            startActivity(GetDevicesFragment.TAG);
+    }
     @Override
     public void onExampleGetSuccess() {
         if (isTwoPane)

--- a/Library/app/src/main/java/com/globallogic/futbol/example/activities/GenericExampleActivity.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/activities/GenericExampleActivity.java
@@ -10,6 +10,7 @@ import com.globallogic.futbol.example.R;
 import com.globallogic.futbol.example.fragments.CreateDeviceFragment;
 import com.globallogic.futbol.example.fragments.DeleteDeviceFragment;
 import com.globallogic.futbol.example.fragments.GetDeviceFragment;
+import com.globallogic.futbol.example.fragments.GetDevicesFragment;
 import com.globallogic.futbol.example.fragments.GetExampleTimeOutFragment;
 import com.globallogic.futbol.example.fragments.PutExampleUpdateDeviceFragment;
 
@@ -32,6 +33,9 @@ public class GenericExampleActivity extends Activity {
             String tag = getIntent().getStringExtra(EXTRA_TAG);
             Fragment fragment = null;
             switch (tag) {
+                case GetDevicesFragment.TAG:
+                    fragment = GetDevicesFragment.newInstance();
+                    break;
                 case GetDeviceFragment.TAG:
                     fragment = GetDeviceFragment.newInstance();
                     break;

--- a/Library/app/src/main/java/com/globallogic/futbol/example/adapters/DevicesAdapter.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/adapters/DevicesAdapter.java
@@ -1,0 +1,98 @@
+package com.globallogic.futbol.example.adapters;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import com.globallogic.futbol.example.BuildConfig;
+import com.globallogic.futbol.example.R;
+import com.globallogic.futbol.example.entities.Device;
+import com.globallogic.futbol.example.interfaces.IDevicesAdapterCallbacks;
+import com.globallogic.futbol.example.viewholders.DeviceViewHolder;
+
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by facundo.mengoni on 10/5/2015.
+ */
+public class DevicesAdapter extends RecyclerView.Adapter<DeviceViewHolder> implements IDevicesAdapterCallbacks {
+    //region Constants
+    public static final String TAG = DevicesAdapter.class.getSimpleName();
+    //endregion
+
+    //region Variables
+    private IDevicesAdapterCallbacks mCallback;
+    private ArrayList<Device> mList = new ArrayList<>();
+    //endregion
+
+    //region Logger
+    public static Logger mLogger;
+
+    static {
+        mLogger = Logger.getLogger(TAG);
+        if (BuildConfig.DEBUG)
+            mLogger.setLevel(Level.ALL);
+        else
+            mLogger.setLevel(Level.OFF);
+    }
+    //endregion
+
+    //region LifeCycle
+    public DevicesAdapter(IDevicesAdapterCallbacks callback) {
+        mCallback = callback;
+    }
+
+    @Override
+    public DeviceViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        return new DeviceViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.view_holder_item, parent, false), this);
+    }
+
+    public void onBindViewHolder(DeviceViewHolder holder, int position) {
+        holder.load(getDevice(position));
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return getDevice(position).getId();
+    }
+
+    @Override
+    public int getItemCount() {
+        return mList.size();
+    }
+    //endregion
+
+    //region Private API
+    private Device getDevice(int aPosition) {
+        return mList.get(aPosition);
+    }
+    // endregion
+
+    //region IDevicesAdapterCallbacks
+    @Override
+    public void onItemClick(int position) {
+        mCallback.onItemClick(position);
+    }
+    // endregion
+
+    //region Public API
+    public void addList(ArrayList<Device> aList) {
+        mList.addAll(new ArrayList<Device>(aList));
+        notifyDataSetChanged();
+    }
+
+    public void update(Device aDevice) {
+        int index = mList.indexOf(aDevice);
+        if (index >= 0) {
+            mList.set(index, aDevice);
+            notifyItemChanged(index);
+        } else {
+            mList.add(aDevice);
+            index = mList.indexOf(aDevice);
+            notifyItemInserted(index);
+        }
+    }
+    // endregion
+}

--- a/Library/app/src/main/java/com/globallogic/futbol/example/entities/Device.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/entities/Device.java
@@ -8,7 +8,7 @@ import java.util.Date;
  * GlobalLogic | facundo.mengoni@globallogic.com
  */
 public class Device implements Serializable {
-    private String id;
+    private Integer id;
     private Date createdAt;
     private Date updatedAt;
     private String name;
@@ -17,11 +17,11 @@ public class Device implements Serializable {
     public Device() {
     }
 
-    public String getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -55,6 +55,26 @@ public class Device implements Serializable {
 
     public void setResolution(String resolution) {
         this.resolution = resolution;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Device device = (Device) o;
+
+        if (id != null && device.id != null) return id.equals(device.id);
+        if (name != null && device.name != null) return name.equals(device.name);
+        return false;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/CreateDeviceFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/CreateDeviceFragment.java
@@ -116,7 +116,7 @@ public class CreateDeviceFragment extends Fragment implements CreateDeviceOperat
 
     private void submit() {
         if (checkRequiredField(vName) && checkRequiredField(vResolution)) {
-            mCreateDeviceOperation.performOperation(vName.getText().toString(), vResolution.getText().toString());
+            mCreateDeviceOperation.execute(vName.getText().toString(), vResolution.getText().toString());
         }
     }
 

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/DeleteDeviceFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/DeleteDeviceFragment.java
@@ -119,7 +119,7 @@ public class DeleteDeviceFragment extends Fragment implements DeleteDeviceOperat
 
     private void submit() {
         if (checkRequiredField(vId)) {
-            mDeleteDeviceOperation.performOperation(vId.getText().toString());
+            mDeleteDeviceOperation.execute(vId.getText().toString());
         }
     }
 

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetDeviceFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetDeviceFragment.java
@@ -25,7 +25,7 @@ public class GetDeviceFragment extends Fragment implements GetDeviceOperation.IG
     private TextView vOperationResult;
 
     public GetDeviceFragment() {
-        String id = "1";
+        Integer id = 1;
         mGetDeviceOperation = new GetDeviceOperation(id);
         mGetDeviceReceiver = new GetDeviceOperation.GetDeviceReceiver(this);
     }
@@ -80,11 +80,7 @@ public class GetDeviceFragment extends Fragment implements GetDeviceOperation.IG
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        submit();
-    }
-
-    private void submit() {
-        mGetDeviceOperation.performOperation();
+        mGetDeviceOperation.execute();
     }
 
     private void updateOperationStatus() {

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetDevicesFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetDevicesFragment.java
@@ -1,0 +1,192 @@
+package com.globallogic.futbol.example.fragments;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+import android.widget.ViewSwitcher;
+
+import com.globallogic.futbol.example.R;
+import com.globallogic.futbol.example.activities.GenericExampleActivity;
+import com.globallogic.futbol.example.adapters.DevicesAdapter;
+import com.globallogic.futbol.example.entities.Device;
+import com.globallogic.futbol.example.interfaces.IDevicesAdapterCallbacks;
+import com.globallogic.futbol.example.operations.GetDeviceOperation;
+import com.globallogic.futbol.example.operations.GetDevicesOperation;
+
+import java.util.ArrayList;
+
+/**
+ * Created by Ezequiel Sanz on 11/05/15.
+ * GlobalLogic | ezequiel.sanz@globallogic.com
+ */
+public class GetDevicesFragment extends Fragment {
+    public static final String TAG = "GetDevicesFragment";
+    private TextView vOperationStatus;
+    private TextView vOperationResult;
+    private ViewSwitcher vOperationResultContainer;
+    private ViewSwitcher vOperationWaitingContainer;
+    private RecyclerView vRecyclerView;
+    private DevicesAdapter mMediasAdapter;
+
+    //region GetDevicesOperation
+    // Defino mi operacion y mi receiver
+    private final GetDevicesOperation mGetDevicesOperation;
+    private final GetDevicesOperation.GetDevicesReceiver mGetDevicesReceiver;
+    private final GetDevicesOperation.IGetDevicesReceiver mGetDevicesCallback = new GetDevicesOperation.IGetDevicesReceiver() {
+        @Override
+        public void onNoInternet() {
+            Toast.makeText(getActivity(), R.string.no_internet, Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onStartOperation() {
+            if (vOperationWaitingContainer.getDisplayedChild() == 0)
+                vOperationWaitingContainer.showNext();
+            updateOperationStatus();
+        }
+
+        @Override
+        public void onSuccess(ArrayList<Device> aList) {
+            mMediasAdapter.addList(aList);
+            if (vOperationResultContainer.getDisplayedChild() == 0)
+                vOperationResultContainer.showNext();
+        }
+
+        @Override
+        public void onError() {
+            vOperationResult.setText(mGetDevicesOperation.getError(getActivity()));
+            if (vOperationResultContainer.getDisplayedChild() == 1)
+                vOperationResultContainer.showPrevious();
+        }
+
+        @Override
+        public void onFinishOperation() {
+            if (vOperationWaitingContainer.getDisplayedChild() == 1)
+                vOperationWaitingContainer.showPrevious();
+            updateOperationStatus();
+        }
+
+    };
+    //endregion
+    //region GetDeviceOperation
+    // Defino mi receiver
+    private final GetDeviceOperation.GetDeviceReceiver mGetDeviceReceiver;
+    private final GetDeviceOperation.IGetDeviceReceiver mGetDeviceCallback = new GetDeviceOperation.IGetDeviceReceiver() {
+        @Override
+        public void onNoInternet() {
+        }
+
+        @Override
+        public void onStartOperation() {
+        }
+
+        @Override
+        public void onSuccess(Device aDevice) {
+            mMediasAdapter.update(aDevice);
+            if (vOperationResultContainer.getDisplayedChild() == 0)
+                vOperationResultContainer.showNext();
+        }
+
+        @Override
+        public void onError() {
+        }
+
+        @Override
+        public void onFinishOperation() {
+            if (vOperationWaitingContainer.getDisplayedChild() == 1)
+                vOperationWaitingContainer.showPrevious();
+        }
+    };
+    //endregion
+
+    public GetDevicesFragment() {
+        String id = "1";
+        mGetDevicesOperation = new GetDevicesOperation(id);
+        mGetDevicesReceiver = new GetDevicesOperation.GetDevicesReceiver(mGetDevicesCallback);
+        mGetDeviceReceiver = new GetDeviceOperation.GetDeviceReceiver(mGetDeviceCallback);
+    }
+
+    public static GetDevicesFragment newInstance() {
+        return new GetDevicesFragment();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mGetDevicesOperation.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_get_example_get_list, container, false);
+        vOperationStatus = (TextView) rootView.findViewById(R.id.operation_status);
+        vOperationResult = (TextView) rootView.findViewById(R.id.operation_result);
+        vOperationResultContainer = (ViewSwitcher) rootView.findViewById(R.id.operation_result_container);
+        vOperationWaitingContainer = (ViewSwitcher) rootView.findViewById(R.id.operation_waiting_container);
+        vRecyclerView = (RecyclerView) rootView.findViewById(R.id.operation_list);
+        vRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, false));
+
+        mMediasAdapter = new DevicesAdapter(new IDevicesAdapterCallbacks() {
+            @Override
+            public void onItemClick(int position) {
+                startActivity(GenericExampleActivity.generateIntent(getActivity(), GetDeviceFragment.TAG));
+            }
+        });
+        vRecyclerView.setAdapter(mMediasAdapter);
+
+        mGetDevicesReceiver.register(mGetDevicesOperation);
+        mGetDeviceReceiver.register(GetDeviceOperation.class);
+
+        return rootView;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        mGetDevicesOperation.execute();
+    }
+
+    private void updateOperationStatus() {
+        switch (mGetDevicesOperation.getStatus()) {
+            case READY_TO_EXECUTE:
+                vOperationStatus.setText("Ready to execute");
+                break;
+            case WAITING_EXECUTION:
+                vOperationStatus.setText("Waiting execution");
+                break;
+            case DOING_EXECUTION:
+                vOperationStatus.setText("Doing execution");
+                break;
+            case FINISHED_EXECUTION:
+                vOperationStatus.setText("Finished execution");
+                break;
+            case UNKNOWN:
+            default:
+                vOperationStatus.setText("Some error");
+                break;
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        //Guardo los datos necesario de la operacion
+        mGetDevicesOperation.onSaveInstanceState(outState);
+    }
+
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        // Desregistro el receiver
+        mGetDevicesReceiver.unRegister();
+        mGetDeviceReceiver.unRegister();
+    }
+}

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetExampleTimeOutFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetExampleTimeOutFragment.java
@@ -79,7 +79,7 @@ public class GetExampleTimeOutFragment extends Fragment implements TimeOutOperat
     }
 
     private void submit() {
-        mTimeOutOperation.performOperation();
+        mTimeOutOperation.execute();
     }
 
     private void updateOperationStatus() {

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetPageFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/GetPageFragment.java
@@ -39,6 +39,7 @@ public class GetPageFragment extends Fragment implements View.OnClickListener {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_get_page, container, false);
+        rootView.findViewById(R.id.fragment_get_page_list_success).setOnClickListener(this);
         rootView.findViewById(R.id.fragment_get_page_success).setOnClickListener(this);
         rootView.findViewById(R.id.fragment_get_page_time_out).setOnClickListener(this);
         return rootView;
@@ -47,6 +48,9 @@ public class GetPageFragment extends Fragment implements View.OnClickListener {
     @Override
     public void onClick(View v) {
         switch (v.getId()) {
+            case R.id.fragment_get_page_list_success:
+                mCallback.onExampleGetListSuccess();
+                break;
             case R.id.fragment_get_page_success:
                 mCallback.onExampleGetSuccess();
                 break;
@@ -57,6 +61,8 @@ public class GetPageFragment extends Fragment implements View.OnClickListener {
     }
 
     public interface ICallback {
+        void onExampleGetListSuccess();
+
         void onExampleGetSuccess();
 
         void onExampleGetTimeout();

--- a/Library/app/src/main/java/com/globallogic/futbol/example/fragments/PutExampleUpdateDeviceFragment.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/fragments/PutExampleUpdateDeviceFragment.java
@@ -126,7 +126,7 @@ public class PutExampleUpdateDeviceFragment extends Fragment implements UpdateDe
 
     private void submit() {
         if (checkRequiredField(vId) && checkRequiredField(vName) && checkRequiredField(vResolution)) {
-            mUpdateDeviceOperation.performOperation(vId.getText().toString(), vName.getText().toString(), vResolution.getText().toString());
+            mUpdateDeviceOperation.execute(vId.getText().toString(), vName.getText().toString(), vResolution.getText().toString());
         }
     }
 

--- a/Library/app/src/main/java/com/globallogic/futbol/example/interfaces/IDevicesAdapterCallbacks.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/interfaces/IDevicesAdapterCallbacks.java
@@ -1,0 +1,8 @@
+package com.globallogic.futbol.example.interfaces;
+
+/**
+ * Created by facundo.mengoni on 10/5/2015.
+ */
+public interface IDevicesAdapterCallbacks {
+    void onItemClick(int position);
+}

--- a/Library/app/src/main/java/com/globallogic/futbol/example/operations/CreateDeviceOperation.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/operations/CreateDeviceOperation.java
@@ -29,6 +29,11 @@ public class CreateDeviceOperation extends ExampleOperation {
         mDevice = null;
     }
 
+    public void execute(String name, String resolution) {
+        reset();
+        performOperation(name, resolution);
+    }
+
     @Override
     protected IOperationStrategy getStrategy(Object... arg) {
         String name = (String) arg[0];

--- a/Library/app/src/main/java/com/globallogic/futbol/example/operations/DeleteDeviceOperation.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/operations/DeleteDeviceOperation.java
@@ -31,6 +31,11 @@ public class DeleteDeviceOperation extends ExampleOperation {
         mNotFound = false;
     }
 
+    public void execute(String id ){
+        reset();
+        performOperation(id);
+    }
+
     @Override
     protected IOperationStrategy getStrategy(Object... arg) {
         String id = (String) arg[0];

--- a/Library/app/src/main/java/com/globallogic/futbol/example/operations/TimeOutOperation.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/operations/TimeOutOperation.java
@@ -14,6 +14,10 @@ import com.globallogic.futbol.example.operations.helper.ExampleOperation;
 public class TimeOutOperation extends ExampleOperation {
     private static final String TAG = TimeOutOperation.class.getSimpleName();
 
+    public void execute(){
+        performOperation();
+    }
+
     @Override
     protected IOperationStrategy getStrategy(Object... arg) {
         StrategyMock strategyMock = new StrategyMock(1.0f);

--- a/Library/app/src/main/java/com/globallogic/futbol/example/operations/UpdateDeviceOperation.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/operations/UpdateDeviceOperation.java
@@ -31,6 +31,11 @@ public class UpdateDeviceOperation extends ExampleOperation {
         mNotFound = false;
     }
 
+    public void execute(String id, String name, String resolution) {
+        reset();
+        performOperation(id, name, resolution);
+    }
+
     @Override
     protected IOperationStrategy getStrategy(Object... arg) {
         String id = (String) arg[0];

--- a/Library/app/src/main/java/com/globallogic/futbol/example/viewholders/DeviceViewHolder.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/viewholders/DeviceViewHolder.java
@@ -1,0 +1,36 @@
+package com.globallogic.futbol.example.viewholders;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.globallogic.futbol.example.R;
+import com.globallogic.futbol.example.entities.Device;
+import com.globallogic.futbol.example.interfaces.IDevicesAdapterCallbacks;
+
+/**
+ * Created by facundo.mengoni on 10/5/2015.
+ */
+public class DeviceViewHolder extends RecyclerView.ViewHolder {
+
+    //region Views
+    TextView vTitle;
+    private IDevicesAdapterCallbacks mCallback;
+    //endregion
+
+    public DeviceViewHolder(View itemView, final IDevicesAdapterCallbacks callback) {
+        super(itemView);
+        mCallback = callback;
+        itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mCallback.onItemClick(getAdapterPosition());
+            }
+        });
+        vTitle = (TextView) itemView.findViewById(R.id.view_holder_item_title);
+    }
+
+    public void load(Device device) {
+        vTitle.setText(device.toString());
+    }
+}

--- a/Library/app/src/main/java/com/globallogic/futbol/example/widgets/MyRecyclerView.java
+++ b/Library/app/src/main/java/com/globallogic/futbol/example/widgets/MyRecyclerView.java
@@ -1,0 +1,29 @@
+package com.globallogic.futbol.example.widgets;
+
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+
+/**
+ * Created by facundo.mengoni on 10/5/2015.
+ */
+public class MyRecyclerView extends RecyclerView {
+    public MyRecyclerView(Context context) {
+        super(context);
+    }
+
+    public MyRecyclerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MyRecyclerView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (getAdapter() != null)
+            setAdapter(null);
+    }
+}

--- a/Library/app/src/main/res/layout/fragment_get_example_get_list.xml
+++ b/Library/app/src/main/res/layout/fragment_get_example_get_list.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/operation_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:freezesText="true"
+        android:padding="5dp"
+        tools:text="READY_FOR_EXECUTE" />
+
+    <ViewSwitcher
+        android:id="@+id/operation_waiting_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/operation_status">
+
+        <ViewSwitcher
+            android:id="@+id/operation_result_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/operation_result"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerInParent="true"
+                    android:freezesText="true" />
+            </RelativeLayout>
+
+            <com.globallogic.futbol.example.widgets.MyRecyclerView
+                android:id="@+id/operation_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical" />
+        </ViewSwitcher>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true" />
+        </RelativeLayout>
+    </ViewSwitcher>
+</RelativeLayout>

--- a/Library/app/src/main/res/layout/fragment_get_page.xml
+++ b/Library/app/src/main/res/layout/fragment_get_page.xml
@@ -10,6 +10,13 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/fragment_get_page_list_success"
+            style="@style/TextItem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/get_list_success"/>
+
+        <TextView
             android:id="@+id/fragment_get_page_success"
             style="@style/TextItem"
             android:layout_width="match_parent"

--- a/Library/app/src/main/res/layout/view_holder_item.xml
+++ b/Library/app/src/main/res/layout/view_holder_item.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/view_holder_item_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="5dp"
+        tools:text="Some item" />
+</LinearLayout>

--- a/Library/app/src/main/res/values/strings.xml
+++ b/Library/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="error_malformed_url_exception">Malformed url exception</string>
     <string name="error_io_exception">I/O exception</string>
     <string name="error_other_exception">General exception</string>
+    <string name="get_list_success">Get list of devices</string>
     <string name="get_success">Get device</string>
     <string name="get_time_out">Time out</string>
     <string name="post_submit">Create device</string>

--- a/Library/app/src/test/java/com/globallogic/futbol/example/GetDeviceOperationTest.java
+++ b/Library/app/src/test/java/com/globallogic/futbol/example/GetDeviceOperationTest.java
@@ -75,7 +75,7 @@ public class GetDeviceOperationTest {
 
     @Test
     public void getDeviceTimeout() {
-        final String id = "1";
+        final Integer id = 1;
         //region Setup
         final GetDeviceOperation mGetDeviceTimeOutOperation = new GetDeviceOperation(id);
         final GetDeviceOperation.IGetDeviceReceiver mGetDeviceTimeOutCallback = new GetDeviceOperation.IGetDeviceReceiver() {
@@ -123,7 +123,7 @@ public class GetDeviceOperationTest {
 
     @Test
     public void getDeviceSuccess() {
-        final String id = "2";
+        final Integer id = 2;
         //region Setup
         final GetDeviceOperation mGetDeviceSuccessOperation = new GetDeviceOperation(id);
         final GetDeviceOperation.IGetDeviceReceiver mGetDeviceSuccessCallback = new GetDeviceOperation.IGetDeviceReceiver() {
@@ -183,7 +183,7 @@ public class GetDeviceOperationTest {
 
     @Test
     public void getDeviceNoInternet() {
-        final String id = "3";
+        final Integer id = 3;
         //region Setup
         setConnectionAs(NetworkInfo.DetailedState.DISCONNECTED, ConnectivityManager.TYPE_WIFI, 0, false);
         final GetDeviceOperation mGetDeviceNoInternetOperation = new GetDeviceOperation(id);
@@ -233,7 +233,7 @@ public class GetDeviceOperationTest {
 
     @Test
     public void getDeviceUnexpectedResponse() {
-        final String id = "4";
+        final Integer id = 4;
         //region Setup
         final GetDeviceOperation mGetDeviceUnexpectedResponseOperation = new GetDeviceOperation(id);
         final GetDeviceOperation.IGetDeviceReceiver mGetDeviceUnexpectedResponseCallback = new GetDeviceOperation.IGetDeviceReceiver() {

--- a/Library/futbol/src/main/java/com/globallogic/futbol/core/operation/strategies/StrategyMockResponse.java
+++ b/Library/futbol/src/main/java/com/globallogic/futbol/core/operation/strategies/StrategyMockResponse.java
@@ -35,4 +35,12 @@ public class StrategyMockResponse implements Serializable {
     public void setResponse(String response) {
         this.response = response;
     }
+
+    @Override
+    public String toString() {
+        return "StrategyMockResponse{" +
+                "httpCode=" + httpCode +
+                ", response='" + response + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
# Refactor de las operaciones
- Se agregaron logs
- Los métodos de test tienen en cuenta el status de la operación
- Se separaron los broadcast de los métodos.
- El reset ya no se llama automáticamente
- El tiempo de espera simulado ahora es exactamente el especificado
# Refactor del ejemplo ajustandose a los cambios del reset
- Se modificaron los json de ejemplo
- Se agregó un ejemplo con un listado de items
- El listado de items escucha por request particulares y actualiza los datos
- Se pasaron todos los .performOperation(...) a .execute(...)
